### PR TITLE
Add APP_VERSION env var and fix CORS issue

### DIFF
--- a/src/main/java/org/cbioportal/session_service/SessionService.java
+++ b/src/main/java/org/cbioportal/session_service/SessionService.java
@@ -39,6 +39,8 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.mongodb.core.mapping.event.ValidatingMongoEventListener;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 
 /**
@@ -56,6 +58,27 @@ public class SessionService extends SpringBootServletInitializer {
     @Bean
     public LocalValidatorFactoryBean validator() {
         return new LocalValidatorFactoryBean();
+    }
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/info/**")
+                        .allowedOriginPatterns("*")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+                
+                // Also allow CORS for all API endpoints if needed
+                registry.addMapping("/api/**")
+                        .allowedOriginPatterns("*")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
     }
 
     public static void main(String[] args) {

--- a/src/main/java/org/cbioportal/session_service/SessionService.java
+++ b/src/main/java/org/cbioportal/session_service/SessionService.java
@@ -67,14 +67,7 @@ public class SessionService extends SpringBootServletInitializer {
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/info/**")
                         .allowedOriginPatterns("*")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                        .allowedHeaders("*")
-                        .allowCredentials(true);
-                
-                // Also allow CORS for all API endpoints if needed
-                registry.addMapping("/api/**")
-                        .allowedOriginPatterns("*")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedMethods("GET", "OPTIONS")
                         .allowedHeaders("*")
                         .allowCredentials(true);
             }

--- a/src/main/java/org/cbioportal/session_service/web/InfoController.java
+++ b/src/main/java/org/cbioportal/session_service/web/InfoController.java
@@ -12,7 +12,7 @@ public class InfoController {
     public String getVersion() {
         // Read from environment variable, fallback to implementation version
         String envVersion = System.getenv("APP_VERSION");
-        if (envVersion != null && !envVersion.isEmpty()) {
+        if (envVersion != null && !envVersion.trim().isBlank()) {
             return envVersion;
         }
         return getClass().getPackage().getImplementationVersion();

--- a/src/main/java/org/cbioportal/session_service/web/InfoController.java
+++ b/src/main/java/org/cbioportal/session_service/web/InfoController.java
@@ -10,6 +10,11 @@ import org.springframework.web.bind.annotation.*;
 public class InfoController {
 
     public String getVersion() {
+        // Read from environment variable, fallback to implementation version
+        String envVersion = System.getenv("APP_VERSION");
+        if (envVersion != null && !envVersion.isEmpty()) {
+            return envVersion;
+        }
         return getClass().getPackage().getImplementationVersion();
     }
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 # filepath: startup.sh
 
+# Set environment variables
+export APP_VERSION=${APP_VERSION}
+
 # Import the RDS cert into a truststore
 keytool -importcert -trustcacerts -alias rds-root -file /tmp/rds-combined-ca-bundle.pem  -keystore /tmp/rds-truststore.jks -storepass abcdef -noprompt
 

--- a/startup.sh
+++ b/startup.sh
@@ -2,7 +2,7 @@
 # filepath: startup.sh
 
 # Set environment variables
-export APP_VERSION=${APP_VERSION}
+export APP_VERSION=${APP_VERSION:-unknown}
 
 # Import the RDS cert into a truststore
 keytool -importcert -trustcacerts -alias rds-root -file /tmp/rds-combined-ca-bundle.pem  -keystore /tmp/rds-truststore.jks -storepass abcdef -noprompt


### PR DESCRIPTION
This pull request introduces CORS support for the `/info/**` endpoint, enables dynamic version reporting via an environment variable, and ensures the application version is set at startup. These changes improve the flexibility and configurability of the service, especially in cloud or containerized environments.

**CORS configuration:**

* Added a `WebMvcConfigurer` bean in `SessionService.java` to allow CORS requests to `/info/**` from any origin, supporting `GET` and `OPTIONS` methods with all headers and credentials enabled. [[1]](diffhunk://#diff-2216324db3836efa846d75ee6c7eaac9675c6fe4dd46e38e8d16ba2e1acc79f0R42-R43) [[2]](diffhunk://#diff-2216324db3836efa846d75ee6c7eaac9675c6fe4dd46e38e8d16ba2e1acc79f0R63-R76)

**Dynamic version reporting:**

* Modified `InfoController.java` to return the application version from the `APP_VERSION` environment variable if set, falling back to the implementation version otherwise.

**Startup script enhancements:**

* Updated `startup.sh` to set the `APP_VERSION` environment variable to `unknown` by default if not already defined.