### PR TITLE
Fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,21 @@ WORKDIR /session-service
 RUN mvn package -DskipTests -Dpackaging.type=jar
 
 # Use the latest patched version to address CVE-2025-50059 and other Java vulnerabilities
+# Fix CVE-2026-21945: Use Eclipse Temurin 21.0.10+ (DoS in Security/certificate checking)
 
-FROM eclipse-temurin:21-alpine AS fnl_base_image
+FROM eclipse-temurin:21.0.10_7-jre-alpine AS fnl_base_image
+
+# Fix CVE-2025-15467: Upgrade OpenSSL to patched version (3.0.19 / 3.3.6 / 3.4.4 / 3.5.5 / 3.6.1+)
+# Stack buffer overflow in CMS AEAD parsing; Alpine delivers fix via apk upgrade
+# Fix CVE-2026-22801: LIBPNG heap buffer over-read in png_write_image_* (libpng 1.6.26–1.6.53).
+# Fixed in libpng 1.6.54+; Alpine 3.20+ ships 1.6.55-r0. apk upgrade below gets patched libpng when base is Alpine 3.20+.
+# Fix CVE-2025-13151: libtasn1 stack buffer overflow in asn1_expend_octet_string (libtasn1 <= 4.20.0).
+# Fixed in libtasn1 4.21.0+; Alpine 3.20+ ships 4.21.0-r0. apk upgrade below gets patched libtasn1 when base is Alpine 3.20+.
+# Fix CVE-2025-32988: GnuTLS double-free in SAN otherName export (gnutls < 3.8.10).
+# Fixed in GnuTLS 3.8.10+; Alpine 3.20+ ships 3.8.12-r0. apk upgrade below gets patched gnutls when base is Alpine 3.20+.
+# Fix CVE-2025-68973: GnuPG out-of-bounds write in armor_filter (gnupg < 2.4.9, or < 2.2.51 ExtendedLTS).
+# Fixed in GnuPG 2.4.9+; Alpine 3.20+ ships gnupg 2.4.9-r0. apk upgrade below gets patched gnupg when base is Alpine 3.20+.
+RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /tmp && chmod 777 /tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,19 @@ FROM eclipse-temurin:21.0.10_7-jre-alpine AS fnl_base_image
 
 # Fix CVE-2025-15467: Upgrade OpenSSL to patched version (3.0.19 / 3.3.6 / 3.4.4 / 3.5.5 / 3.6.1+)
 # Stack buffer overflow in CMS AEAD parsing; Alpine delivers fix via apk upgrade
+# Fix CVE-2026-25210: libexpat integer overflow in doContent/tag buffer reallocation (expat < 2.7.4).
+# Fixed in expat 2.7.4+; Alpine 3.20+ ships 2.7.4-r0. apk upgrade below gets patched expat when base is Alpine 3.20+.
 # Fix CVE-2026-22801: LIBPNG heap buffer over-read in png_write_image_* (libpng 1.6.26–1.6.53).
 # Fixed in libpng 1.6.54+; Alpine 3.20+ ships 1.6.55-r0. apk upgrade below gets patched libpng when base is Alpine 3.20+.
 # Fix CVE-2025-13151: libtasn1 stack buffer overflow in asn1_expend_octet_string (libtasn1 <= 4.20.0).
 # Fixed in libtasn1 4.21.0+; Alpine 3.20+ ships 4.21.0-r0. apk upgrade below gets patched libtasn1 when base is Alpine 3.20+.
 # Fix CVE-2025-32988: GnuTLS double-free in SAN otherName export (gnutls < 3.8.10).
+# Fix CVE-2024-12243: GnuTLS/libtasn1 DoS via inefficient DER cert decoding (gnutls 3.8.11+ / 3.8.12+ on Alpine).
 # Fixed in GnuTLS 3.8.10+; Alpine 3.20+ ships 3.8.12-r0. apk upgrade below gets patched gnutls when base is Alpine 3.20+.
 # Fix CVE-2025-68973: GnuPG out-of-bounds write in armor_filter (gnupg < 2.4.9, or < 2.2.51 ExtendedLTS).
 # Fixed in GnuPG 2.4.9+; Alpine 3.20+ ships gnupg 2.4.9-r0. apk upgrade below gets patched gnupg when base is Alpine 3.20+.
+# Fix CVE-2025-46394: BusyBox tar filenames hidden via terminal escape sequences (busybox through 1.37.0).
+# Fixed in busybox 1.36.1-r31 (3.20), 1.36.1-r21 (3.19), 1.37.0-r14+ (3.21+). apk upgrade below gets patched busybox when base is Alpine 3.19+.
 RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /tmp && chmod 777 /tmp

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.18.0</version>
       </dependency>
-      <!-- force fixed Tomcat (covers core, websocket, el, jasper etc.) -->
+      <!-- Force fixed Tomcat (covers core, websocket, el, jasper etc.). Fix CVE-2025-66614: client cert auth bypass via SNI/host header (11.x <= 11.0.14); fixed in 11.0.15+. -->
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>
@@ -136,11 +136,16 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-       <!-- Fix logback-core CVE -->
+      <!-- Fix CVE-2026-1225: logback arbitrary class instantiation via config (<= 1.5.24). Fixed in 1.5.25+. Keep logback-core and logback-classic on same version to avoid NoSuchMethodError (initCollisionMaps). -->
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>1.5.19</version>
+        <version>1.5.25</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.5.25</version>
       </dependency>
       <!-- Fix GHSA-72hv-8253-57qq: jackson-core async parser DoS (maxNumberLength bypass) -->
       <dependency>
@@ -153,7 +158,7 @@
   
   <properties>
     <java.version>21</java.version>
-    <tomcat.version>11.0.12</tomcat.version>
+    <tomcat.version>11.0.15</tomcat.version>
   <spring-framework.version>6.2.11</spring-framework.version>
   </properties>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,12 @@
         <artifactId>logback-core</artifactId>
         <version>1.5.19</version>
       </dependency>
+      <!-- Fix GHSA-72hv-8253-57qq: jackson-core async parser DoS (maxNumberLength bypass) -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.21.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   


### PR DESCRIPTION
This pull request focuses on upgrading dependencies and base images to address several critical security vulnerabilities in both the application runtime and its libraries. The most important changes include updating the Docker base image to a patched version, upgrading Tomcat and other libraries to fix recent CVEs, and ensuring Alpine system packages are up-to-date for additional security fixes.

**Security upgrades to runtime and dependencies:**

* Upgraded the Docker base image to `eclipse-temurin:21.0.10_7-jre-alpine` to fix CVE-2026-21945 (Denial of Service in Java Security/certificate checking), and added comments for several other CVEs addressed by Alpine package upgrades (OpenSSL, libexpat, libpng, libtasn1, GnuTLS, GnuPG, BusyBox). Also added `apk update && apk upgrade` to ensure all system packages are patched.

**Dependency updates for CVE fixes:**

* Updated Tomcat dependencies and the `tomcat.version` property to `11.0.15` to fix CVE-2025-66614 (client certificate authentication bypass via SNI/host header). [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L121-R121) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L139-R161)
* Upgraded `logback-core` and added `logback-classic` dependency to version `1.5.25` to fix CVE-2026-1225 (arbitrary class instantiation via configuration). Ensured versions are synced to avoid runtime errors.
* Added/updated `jackson-core` to version `2.21.1` to address GHSA-72hv-8253-57qq (DoS via async parser maxNumberLength bypass).

These changes collectively strengthen the application's security posture by ensuring that both the runtime environment and core libraries are protected against known vulnerabilities.