### PR TITLE
Fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ FROM maven:3-eclipse-temurin-21 AS build
 COPY $PWD /session-service
 WORKDIR /session-service
 RUN mvn package -DskipTests -Dpackaging.type=jar
+# Fetch RDS CA bundle in build stage so the runtime image does not need curl (CVE-2026-3805 etc.).
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+  && curl -fsSL -o /session-service/rds-combined-ca-bundle.pem \
+    https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem \
+  && rm -rf /var/lib/apt/lists/*
 
 FROM eclipse-temurin:21-alpine-3.23 AS fnl_base_image
 
@@ -15,8 +20,7 @@ RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /tmp && chmod 777 /tmp
 
-# Add AWS DocumentDB certificate
-RUN apk add curl && curl -o /tmp/rds-combined-ca-bundle.pem https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
+COPY --from=build /session-service/rds-combined-ca-bundle.pem /tmp/rds-combined-ca-bundle.pem
 
 # copy over target/session_service-x.y.z.jar ignore *-model.jar, that jar is
 # used by cbioportal/cbioportal to import the models

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,26 +9,8 @@ COPY $PWD /session-service
 WORKDIR /session-service
 RUN mvn package -DskipTests -Dpackaging.type=jar
 
-# Use the latest patched version to address CVE-2025-50059 and other Java vulnerabilities
-# Fix CVE-2026-21945: Use Eclipse Temurin 21.0.10+ (DoS in Security/certificate checking)
+FROM eclipse-temurin:21-alpine-3.23 AS fnl_base_image
 
-FROM eclipse-temurin:21.0.10_7-jre-alpine AS fnl_base_image
-
-# Fix CVE-2025-15467: Upgrade OpenSSL to patched version (3.0.19 / 3.3.6 / 3.4.4 / 3.5.5 / 3.6.1+)
-# Stack buffer overflow in CMS AEAD parsing; Alpine delivers fix via apk upgrade
-# Fix CVE-2026-25210: libexpat integer overflow in doContent/tag buffer reallocation (expat < 2.7.4).
-# Fixed in expat 2.7.4+; Alpine 3.20+ ships 2.7.4-r0. apk upgrade below gets patched expat when base is Alpine 3.20+.
-# Fix CVE-2026-22801: LIBPNG heap buffer over-read in png_write_image_* (libpng 1.6.26–1.6.53).
-# Fixed in libpng 1.6.54+; Alpine 3.20+ ships 1.6.55-r0. apk upgrade below gets patched libpng when base is Alpine 3.20+.
-# Fix CVE-2025-13151: libtasn1 stack buffer overflow in asn1_expend_octet_string (libtasn1 <= 4.20.0).
-# Fixed in libtasn1 4.21.0+; Alpine 3.20+ ships 4.21.0-r0. apk upgrade below gets patched libtasn1 when base is Alpine 3.20+.
-# Fix CVE-2025-32988: GnuTLS double-free in SAN otherName export (gnutls < 3.8.10).
-# Fix CVE-2024-12243: GnuTLS/libtasn1 DoS via inefficient DER cert decoding (gnutls 3.8.11+ / 3.8.12+ on Alpine).
-# Fixed in GnuTLS 3.8.10+; Alpine 3.20+ ships 3.8.12-r0. apk upgrade below gets patched gnutls when base is Alpine 3.20+.
-# Fix CVE-2025-68973: GnuPG out-of-bounds write in armor_filter (gnupg < 2.4.9, or < 2.2.51 ExtendedLTS).
-# Fixed in GnuPG 2.4.9+; Alpine 3.20+ ships gnupg 2.4.9-r0. apk upgrade below gets patched gnupg when base is Alpine 3.20+.
-# Fix CVE-2025-46394: BusyBox tar filenames hidden via terminal escape sequences (busybox through 1.37.0).
-# Fixed in busybox 1.36.1-r31 (3.20), 1.36.1-r21 (3.19), 1.37.0-r14+ (3.21+). apk upgrade below gets patched busybox when base is Alpine 3.19+.
 RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /tmp && chmod 777 /tmp
@@ -36,22 +18,10 @@ RUN mkdir -p /tmp && chmod 777 /tmp
 # Add AWS DocumentDB certificate
 RUN apk add curl && curl -o /tmp/rds-combined-ca-bundle.pem https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
 
-# Fix CVE-2025-6965: Upgrade SQLite to version 3.50.2 or above
-# Fix CVE-2025-40909: Upgrade Perl to address threads working directory race condition
-# Add AWS DocumentDB certificate
-# RUN apt-get update && \
-#     apt-get upgrade -y libsqlite3-0 perl perl-base && \
-#     apt-get install -y curl && \
-#     curl -o /tmp/rds-combined-ca-bundle.pem https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem && \
-#     apt-get clean && \
-#     rm -rf /var/lib/apt/lists/*
-
-
 # copy over target/session_service-x.y.z.jar ignore *-model.jar, that jar is
 # used by cbioportal/cbioportal to import the models
 COPY --from=build /session-service/target/*[0-9].jar /app.war
 # CMD java ${JAVA_OPTS} -jar /app.war
-
 
 # Copy and set up startup script
 COPY startup.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 
 FROM eclipse-temurin:21-alpine-3.23 AS fnl_base_image
 
-RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache --upgrade libpng \
+    && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /tmp && chmod 777 /tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # version 3, or (at your option) any later version.
 #
 
-FROM maven:3-eclipse-temurin-21 as build
+FROM maven:3-eclipse-temurin-21 AS build
 COPY $PWD /session-service
 WORKDIR /session-service
 RUN mvn package -DskipTests -Dpackaging.type=jar

--- a/pom.xml
+++ b/pom.xml
@@ -129,10 +129,11 @@
         <artifactId>tomcat-embed-websocket</artifactId>
         <version>${tomcat.version}</version>
       </dependency>
+      <!-- Fix CVE-2026-22732: servlet apps may not get security HTTP headers (CSP/HSTS/cache). Fixed in 6.5.9+. -->
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-bom</artifactId>
-        <version>6.5.4</version>
+        <version>6.5.9</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -159,7 +160,8 @@
   <properties>
     <java.version>21</java.version>
     <tomcat.version>11.0.18</tomcat.version>
-  <spring-framework.version>6.2.11</spring-framework.version>
+    <!-- Fix CVE-2026-22737: path limitation bypass with script view templates (MVC/WebFlux). Fixed in 6.2.17+. -->
+    <spring-framework.version>6.2.17</spring-framework.version>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.18.0</version>
       </dependency>
-      <!-- Force fixed Tomcat (covers core, websocket, el, jasper etc.). Fix CVE-2025-66614: client cert auth bypass via SNI/host header (11.x <= 11.0.14); fixed in 11.0.15+. -->
+      <!-- Force fixed Tomcat (covers core, websocket, el, jasper etc.). Fix CVE-2025-66614: client cert auth bypass (11.0.15+). Fix CVE-2026-24734: OCSP revocation bypass (11.0.18+). -->
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>
@@ -158,7 +158,7 @@
   
   <properties>
     <java.version>21</java.version>
-    <tomcat.version>11.0.15</tomcat.version>
+    <tomcat.version>11.0.18</tomcat.version>
   <spring-framework.version>6.2.11</spring-framework.version>
   </properties>
   <build>


### PR DESCRIPTION
This pull request primarily updates dependencies and Dockerfile practices to address recent security vulnerabilities and streamline certificate handling. The most significant changes include upgrading Spring and Tomcat to patched versions, updating the Spring Security BOM, and improving how the AWS RDS CA bundle is managed in the Docker build process.

**Dependency and Security Updates:**

* Upgraded `spring-framework.version` to `6.2.17` to address CVE-2026-22737 (path limitation bypass with script view templates).
* Upgraded `tomcat.version` to `11.0.18` to address CVE-2025-66614 (client cert auth bypass) and CVE-2026-24734 (OCSP revocation bypass). [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L161-R164) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L121-R121)
* Upgraded `spring-security-bom` to `6.5.9` to fix CVE-2026-22732 (servlet apps may not get security HTTP headers).

**Dockerfile and Certificate Handling:**

* Moved the download of the AWS RDS CA bundle to the build stage, so the runtime image no longer requires `curl`, reducing attack surface and improving security (addresses issues like CVE-2026-3805). The CA bundle is now fetched in the build stage and copied into the runtime image.
* Updated the base image to `eclipse-temurin:21-alpine-3.23` and removed old, commented-out or redundant certificate and security patch commands, relying on Alpine's patched packages.